### PR TITLE
more small suggestions

### DIFF
--- a/example/publiccode.yml
+++ b/example/publiccode.yml
@@ -1,17 +1,16 @@
-version: "0.1" /                    # publiccode YAML standard version 0.0.1
+version: "0.1"                              # publiccode yaml format version
 url: "https://example.com/italia/repo.git"  # URL of this repository
 
 legal:
-  main-copyright-owner: Comune di Reggio Emilia e amici
-  repo-owner: Comune di Reggio Emilia # copyright owner
-  authors-file: AUTHORS             # file listing copyright information
+  main_copyright_owner: Comune di Reggio Emilia e amici
+  repo_owner: Comune di Reggio Emilia # copyright owner
   license: AGPL-3.0-or-later        # SPDX expression of license
 
 maintenance:                        # Maintainance status as open-source software
-  type: commercial                  # Whether there is a commercial contract of maintainance in place. No -> community
-  until: "2019-01-01"               # If maintainance-type is commercial, then the maintenance contract is due
+  type: commercial                  # 'commercial' if there is a commercial contract of maintainance in place, 'community' elsewhere
+  until: "2019-01-31"               # If maintainance type is commercial, then the maintenance contract is due
   maintainer: Company Spa           # Name of the lead maintainer
-  technical-contacts:               # Name of the people that are currently technically maintaining this software
+  technical_contacts:               # Name of the people that are currently technically maintaining this software
   - name: Francesco Rossi
     email: "francesco.rossi@comune.reggioemilia.it"
     affiliation: Comune di Reggio Emilia
@@ -39,22 +38,22 @@ description:
     released: 2017-04-15                                  # Date of last stable software release 
     platforms: web                    # or Windows, Mac, Linux, etc. 
 
-it-riuso:
+it_riuso:
   ipa: BF14X            # Codice IPA della PA che ha pubblicato questo repo (repo-owner)
 
-it-pianotriennale:      # Aderenza al piano triennale. Chiave sotto namespace "ita-", quindi solo italiana
-  use-spid: yes         # yes, no, or "n/a" se il software non ha un login
-  use-pagopa: yes
+it_pianotriennale:      # Aderenza al piano triennale. Chiave sotto namespace "ita-", quindi solo italiana
+  use_spid: yes         # yes, no, or "n/a" se il software non ha un login
+  use_pagopa: yes
 
 meta:                            # Meta information to help categorization of this software
   - scope: it
-    pa-type: city 
+    pa_type: city 
     category: it-anagrafe        # Category list in National Guidelines (possibly, per-country)
     tags:
       - comune
       - anagrafe
       - cittadino
-    used-by:                     # Which other public administrations are known to use this software
+    used_by:                     # Which other public administrations are known to use this software
       - Comune di Firenze
       - Comune di Roma 
 


### PR DESCRIPTION
- clarify date format
- use underscore instead of hyphens: apart from being more readable (subjective) it better aligns with most of the JSON API formats and standard configurations (ie. Jekyll configuration uses underscores)
- fix extraneous slash in first line
- why we need a link to the AUTHORS file (and not to the LICENSE file ?). Probably these are pretty standard paths (and easily discoverable) so we may get rid of the 'authors-file' field

I think that a 'role' field in the contacts section would be useful (I generally like to know if I'm writing to an administrative contact or a developer : )